### PR TITLE
Add more data to estimator_status message

### DIFF
--- a/mavros/launch/px4_pluginlists.yaml
+++ b/mavros/launch/px4_pluginlists.yaml
@@ -1,4 +1,5 @@
 plugin_blacklist:
+- guided_target
 # common
 - safety_area
 # extras

--- a/mavros/src/plugins/sys_status.cpp
+++ b/mavros/src/plugins/sys_status.cpp
@@ -1057,6 +1057,15 @@ private:
 		est_status_msg->accel_error_status_flag = !!(status.flags & enum_value(ESF::ACCEL_ERROR));
 		// [[[end]]] (checksum: da59238f4d4337aeb395f7205db08237)
 
+		est_status_msg->vel_ratio = status.vel_ratio;
+		est_status_msg->pos_horiz_ratio = status.pos_horiz_ratio;
+		est_status_msg->pos_vert_ratio = status.pos_vert_ratio;
+		est_status_msg->mag_ratio = status.mag_ratio;
+		est_status_msg->hagl_ratio = status.hagl_ratio;
+		est_status_msg->tas_ratio = status.tas_ratio;
+		est_status_msg->pos_horiz_accuracy = status.pos_horiz_accuracy;
+		est_status_msg->pos_vert_accuracy = status.pos_vert_accuracy;
+
 		estimator_status_pub.publish(est_status_msg);
 	}
 

--- a/mavros_msgs/msg/EstimatorStatus.msg
+++ b/mavros_msgs/msg/EstimatorStatus.msg
@@ -21,3 +21,12 @@ bool pred_pos_horiz_abs_status_flag
 
 bool gps_glitch_status_flag
 bool accel_error_status_flag
+
+float32 vel_ratio # Velocity innovation test ratio
+float32 pos_horiz_ratio # Horizontal position innovation test ratio
+float32 pos_vert_ratio # Vertical position innovation test ratio
+float32 mag_ratio # Magnetometer innovation test ratio
+float32 hagl_ratio # Height above terrain innovation test ratio
+float32 tas_ratio # True airspeed innovation test ratio
+float32 pos_horiz_accuracy # [m] Horizontal position 1-STD accuracy relative to the EKF local origin
+float32 pos_vert_accuracy # [m] Vertical position 1-STD accuracy relative to the EKF local origin


### PR DESCRIPTION
# Changelog
1. Blacklist a plugin that gives an annoying warning in simulation
2. Add all available data from the MAVLINK estimator_status message to the corresponding MAVROS message

Tested in simulation :heavy_check_mark: 